### PR TITLE
babel-register@6.6.0 untested ⚠️

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "babel-preset-es2015": "^6.5.0",
     "babel-preset-react": "^6.5.0",
     "babel-preset-stage-0": "^6.5.0",
-    "babel-register": "^6.5.2",
+    "babel-register": "^6.6.0",
     "css-loader": "^0.23.1",
     "eslint-config-standard": "^5.1.0",
     "eslint-plugin-react": "^4.1.0",


### PR DESCRIPTION
Hello :wave:

:warning::warning::warning:

[babel-register](https://www.npmjs.com/package/babel-register) just published its new version 6.6.0, which **is covered by your current version range**. **No automated tests** are configured for this project.

This means it’s now **unclear whether your software still works**. Manually check if that’s still the case
and close this pull request – if it broke, use this branch to work on adaptions and fixes.

<sub>
Do you think getting a pull request for every single new version of your dependencies is too noisy?
Configure continuous integration and you will only receive them when tests fail. 
</sub>

Happy fixing and merging :palm_tree:

---

This pull request was created by [greenkeeper.io](http://greenkeeper.io/).
It keeps your software, up to date, all the time.

<sub>
Tired of seeing this sponsor message? Upgrade to the supporter plan!
You'll also get your pull requests faster :zap:
</sub>
